### PR TITLE
Add a PCG RNG benchmark.

### DIFF
--- a/PCG.h
+++ b/PCG.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// define constants like M_PI and C keywords for MSVC
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#include <math.h>
+#endif
+
+#include <stdint.h>
+#include <cmath>
+
+namespace at {
+
+class pcg_engine {
+public:
+  inline explicit pcg_engine(uint64_t initstate = 0x853c49e6748fea9bULL, uint64_t initseq = 0xda3e39cb94b95bdbULL) {
+    rng.state = 0U;
+    rng.inc = (initseq << 1u) | 1u;
+    pcg32_random_r();
+    rng.state += initstate;
+    pcg32_random_r();
+  }
+
+  inline uint32_t operator()() {
+      return pcg32_random_r();
+  }
+
+  void advance(uint64_t delta) {
+    uint64_t cur_mult = PCG_DEFAULT_MULTIPLIER_64;
+    uint64_t cur_plus = rng.inc;
+    uint64_t acc_mult = 1u;
+    uint64_t acc_plus = 0u;
+    while (delta > 0) {
+        if (delta & 1) {
+            acc_mult *= cur_mult;
+            acc_plus = acc_plus * cur_mult + cur_plus;
+        }
+        cur_plus = (cur_mult + 1) * cur_plus;
+        cur_mult *= cur_mult;
+        delta /= 2;
+    }
+    rng.state = acc_mult * rng.state + acc_plus;
+  }
+
+private:
+    typedef struct { uint64_t state;  uint64_t inc; } pcg32_random_t;
+    pcg32_random_t rng;
+    static const uint64_t PCG_DEFAULT_MULTIPLIER_64 = 6364136223846793005ULL;
+
+
+    uint64_t pcg32_random_r() {
+        uint64_t oldstate = rng.state;
+        rng.state = oldstate * PCG_DEFAULT_MULTIPLIER_64 + rng.inc;
+        uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+        uint32_t rot = oldstate >> 59u;
+        return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+    }
+};
+
+typedef pcg_engine pcg;
+
+} // namespace at

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -9,6 +9,7 @@
 
 void philox(uint64_t loop_count);
 void at_mt19937(uint64_t loop_count);
+void at_pcg(uint64_t loop_count);
 void std_mt19937(uint64_t loop_count);
 void std_mt19937_at_uniform(uint64_t loop_count);
 
@@ -16,6 +17,7 @@ int main(){
     auto loop_count = 100000000UL;
     philox(loop_count);
     at_mt19937(loop_count);
+    at_pcg(loop_count);
     std_mt19937(loop_count);
     std_mt19937_at_uniform(loop_count);
 }

--- a/functions.cpp
+++ b/functions.cpp
@@ -1,5 +1,6 @@
 #include "Philox.h"
 #include "MT19937.h"
+#include "PCG.h"
 #include <iostream>
 #include <random>
 #include <chrono>
@@ -40,6 +41,19 @@ void at_mt19937(uint64_t loop_count = 1000000000UL) {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = end-start;
     std::cout << "Time to get " << loop_count << " at::mt19937 randoms with at::uniform_real_distribution = " << diff.count() << "s" << std::endl;
+    std::cout << "X value is " << x << std::endl;
+}
+
+void at_pcg(uint64_t loop_count = 1000000000UL) {
+    float x = 0;
+    at::pcg gen1;
+    auto start = std::chrono::high_resolution_clock::now();
+    for(uint64_t i = 0; i < loop_count; i++) {
+        x = to_float_from_uint(gen1());
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = end-start;
+    std::cout << "Time to get " << loop_count << " at::pcg randoms with at::uniform_real_distribution = " << diff.count() << "s" << std::endl;
     std::cout << "X value is " << x << std::endl;
 }
 


### PR DESCRIPTION
PCG is strong PRNG family that is also very fast and supports the advance() functionality needed for parallel evaluation.  This benchmark is pretty directly taken from the "minimal C" implementation on http://www.pcg-random.org/

On my machine, it benchmarks favorable compared to both MT and Philox:

> Time to get 100000000 philox randoms with at::uniform_real_distribution = 0.528258s
> X value is 0.128836
> Time to get 100000000 at::mt19937 randoms with at::uniform_real_distribution = 0.294077s
> X value is 0.365931
> Time to get 100000000 at::pcg randoms with at::uniform_real_distribution = 0.18763s
> X value is 0.446832
> Time to get 100000000 std::mt19937 randoms with std::uniform_real_distribution = 0.395134s
> X value is 0.365931
> Time to get 100000000 std::mt19937 randoms with at::uniform_real_distribution = 0.492973s
> X value is 0.365931

